### PR TITLE
Fix calculation of theta in Gardner class

### DIFF
--- a/src/pedon/soil.py
+++ b/src/pedon/soil.py
@@ -3,8 +3,7 @@ import logging
 from bisect import bisect_right
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Type
-from typing_extensions import Self
+from typing import Literal, Self, Type
 
 
 from numpy import abs as npabs

--- a/src/pedon/soil.py
+++ b/src/pedon/soil.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Literal, Self, Type
 
 
+
 from numpy import abs as npabs
 from numpy import (
     append,

--- a/src/pedon/soil.py
+++ b/src/pedon/soil.py
@@ -3,7 +3,9 @@ import logging
 from bisect import bisect_right
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Self, Type
+from typing import Literal, Type
+from typing_extensions import Self
+
 
 from numpy import abs as npabs
 from numpy import (

--- a/src/pedon/soilmodel.py
+++ b/src/pedon/soilmodel.py
@@ -209,10 +209,10 @@ class Gardner:
 
     def theta(self, h: FloatArray) -> FloatArray:
         # mathematical formulation from Hwang & Powers (2003) https://doi.org/10.1016/S0309-1708(02)00107-0
-        return self.theta_r  +  (self.theta_s - self.theta_r) * ( (1 + .5 * self.c * npabs(h)) * exp(-.5 * self.c * npabs(h)) )
+        return self.theta_r  +  (self.theta_s - self.theta_r) * ( ( (1 + .5 * self.c * npabs(h)) * exp(-.5 * self.c * npabs(h)) )**( 2/(self.m + 2) ) )
 
     def s(self, h: FloatArray) -> FloatArray:
-        return self.theta(h) / self.theta_s
+        return (self.theta(h) -  self.theta_r) / (self.theta_s - self.theta_r)
 
     def k_r(self, h: FloatArray, s: FloatArray | None = None) -> FloatArray:
         return exp(-self.c * npabs(h))

--- a/src/pedon/soilmodel.py
+++ b/src/pedon/soilmodel.py
@@ -208,7 +208,8 @@ class Gardner:
     m: float
 
     def theta(self, h: FloatArray) -> FloatArray:
-        return self.theta_r + (self.theta_s - self.theta_r) * exp(-self.m * npabs(h))
+        # mathematical formulation from Hwang & Powers (2003) https://doi.org/10.1016/S0309-1708(02)00107-0
+        return self.theta_r  +  (self.theta_s - self.theta_r) * ( (1 + .5 * self.c * npabs(h)) * exp(-.5 * self.c * npabs(h)) )
 
     def s(self, h: FloatArray) -> FloatArray:
         return self.theta(h) / self.theta_s

--- a/src/pedon/soilmodel.py
+++ b/src/pedon/soilmodel.py
@@ -203,11 +203,12 @@ class Gardner:
 
     k_s: float
     theta_s: float
+    theta_r: float
     c: float
     m: float
 
     def theta(self, h: FloatArray) -> FloatArray:
-        return self.theta_s * exp(-self.m * npabs(h))
+        return self.theta_r + (self.theta_s - self.theta_r) * exp(-self.m * npabs(h))
 
     def s(self, h: FloatArray) -> FloatArray:
         return self.theta(h) / self.theta_s


### PR DESCRIPTION
I believe the mathematical formulation for calculating theta in the Gardner class was wrong. I replaced it with a formulation derived from 

Hwang, S. I., & Powers, S. E. (2003). Estimating unique soil hydraulic parameters for sandy media from multi-step outflow experiments. Advances in water resources, 26(4), 445-456.