### PR TITLE
feat: add two methods for Gardner parameter approximation based on Peche et al. (in prep) and based on Ghezzehei et al. (2007)

### DIFF
--- a/src/pedon/soil.py
+++ b/src/pedon/soil.py
@@ -469,17 +469,17 @@ class SoilSample:
         )
 
     def gardner_parameter_approximation(
-        self, k_s: float, n: float, theta_s: float
+        self, k_s: float, a: float, n: float, theta_s: float
     ) -> Gardner:
         """
-        Estimation of the Gardner c using van Genuchten's n and the method by
+        Estimation of the Gardner c using van Genuchten's alpha and the method by
         Peche, A., Vonk, M.A., Houben, G. & Bakker, M. (in preparation). Approximation of the Gardner relative conductivity curve parameter from the van Genuchten shape parameter n
         """
-        if n < 2 or n > 8:
+        if n < 1.9:
             logging.error(
                 "n out of model limits for model after Peche et al. (in prep.)."
             )
-        c = 0.013 * exp(0.26 * n)
+        c = 1.94 * a
         return Gardner(k_s=k_s, theta_s=theta_s, m=c, c=c)
 
     def ghezzehei(self, k_s: float, alpha: float, n: float, theta_s: float) -> Gardner:

--- a/src/pedon/soil.py
+++ b/src/pedon/soil.py
@@ -24,7 +24,7 @@ from scipy.optimize import fixed_point, least_squares
 
 from ._params import get_params
 from ._typing import FloatArray
-from .soilmodel import Brooks, Genuchten, SoilModel, get_soilmodel
+from .soilmodel import Brooks, Gardner, Genuchten, SoilModel, get_soilmodel
 
 
 @dataclass
@@ -467,6 +467,32 @@ class SoilSample:
             alpha=10 ** vgpar[2],
             n=10 ** vgpar[3],
         )
+
+    def gardner_parameter_approximation(
+        self, k_s: float, n: float, theta_s: float
+    ) -> Gardner:
+        """
+        Estimation of the Gardner c using van Genuchten's n and the method by
+        Peche, A., Vonk, M.A., Houben, G. & Bakker, M. (in preparation). Approximation of the Gardner relative conductivity curve parameter from the van Genuchten shape parameter n
+        """
+        if n < 2 or n > 8:
+            logging.error(
+                "n out of model limits for model after Peche et al. (in prep.)."
+            )
+        c = 0.013 * exp(0.26 * n)
+        return Gardner(k_s=k_s, theta_s=theta_s, m=c, c=c)
+
+    def ghezzehei(self, k_s: float, alpha: float, n: float, theta_s: float) -> Gardner:
+        """
+        Estimation of the Gardner c using van Genuchten's n, alpha and the method by
+        Ghezzehei, T. A., Kneafsey, T. J., & Su, G. W. (2007). Correspondence of the Gardner and van Genuchten–Mualem relative permeability function parameters. Water resources research, 43(10).
+        """
+        if n < 2:
+            logging.error(
+                "n out of model limits for model after Ghezzehei et al. (2007)."
+            )
+        c = 1.3 * n * alpha
+        return Gardner(k_s=k_s, theta_s=theta_s, m=c, c=c)
 
     def hypags(self) -> Genuchten:
         """


### PR DESCRIPTION
Hi @martinvonk, I implemented two methods for the approximation of Gardner's c. Our newly developed method and an old method from Ghezzehei et al. (2007). Below you find two plots for comparing our methods (including the vG soil hydraulic functions for comparison). 

Btw: I used a different fitting routine which automatically weights the curve fitting towards the turning point in the rcf. This yielded totally different results (!) and a different model. Now, the model is simple and linear and dependent of vG alpha (and not n). It's validity range increased dramatically (valid for vG n >1.9) and performance compared with the Ghezzehei et al. (2007) model improved. For n > 3, our model outperforms the Ghezzehei model. Drawback of all that is that I have to rewrite the manuscript. So, please do not work on that at the moment. 

Here are some plots:
`# shared properties
k_s = 100  # saturated conductivity [cm/d]
theta_r = 0.03  # residual water content [-]
theta_s = 0.42  # saturated water content [-]

# Mualem-van Genuchten
alpha = .01  # shape parameter [1/cm]
n = 3  # shape parameter [-]`

<img width="518" height="426" alt="test_Ghezzehei" src="https://github.com/user-attachments/assets/212c4067-4d69-4b99-908a-a4b6b9c5a9d4" />


<img width="496" height="426" alt="test_our_new_model" src="https://github.com/user-attachments/assets/6a798264-2b73-4434-956d-080cff16f89b" />

 